### PR TITLE
user now able to delete a category from the category manager page

### DIFF
--- a/src/components/categories/CategoriesList.js
+++ b/src/components/categories/CategoriesList.js
@@ -7,7 +7,7 @@ import ArrowForwardIosIcon from '@material-ui/icons/ArrowForwardIos';
 import { Category } from "@material-ui/icons";
 
 export const CategoriesList = (props) => {
-    const { categories, getAllCategories, addCategory } = useContext(CategoryContext)
+    const { categories, getAllCategories, addCategory, deleteCategory  } = useContext(CategoryContext)
     const [category, setCategory] = useState({})
 
     useEffect(() => {
@@ -68,7 +68,11 @@ export const CategoriesList = (props) => {
                     categories.map(c => {
                         return <section key={c.id} className="categories">
                                     <div className="categoryLabel"> {c.label} </div>
-                                </section>                           
+                                    <button className="cat-del-btn" onClick={evt=>{
+                                    evt.preventDefault()
+                                    deleteCategory(c.id)}}
+                                    >X</button>
+                                 </section>                         
                     })
                 }
             </article>

--- a/src/components/categories/CategoriesProvider.js
+++ b/src/components/categories/CategoriesProvider.js
@@ -16,10 +16,14 @@ export const CategoriesProvider = (props) => {
             .then(setCategories)
     }
 
-    const getSingleCategory = (category) => {
-        return fetch(`http://localhost:8000/categories/${category}`)
-            .then(res => res.json())
-            .then(setCategory)
+    const deleteCategory = (categoryId) => {
+        return fetch(`http://localhost:8000/categories/${categoryId}`, {
+        method: "DELETE",
+        headers:{
+            "Authorization": `Token ${localStorage.getItem("rareUser_id")}`
+        }
+     })
+            .then(getAllCategories)
     }
 
     const addCategory = category => {
@@ -36,7 +40,7 @@ export const CategoriesProvider = (props) => {
 
     return (
         <CategoryContext.Provider value={{
-            categories, getAllCategories, category, getSingleCategory, addCategory
+            categories, getAllCategories, category, deleteCategory, addCategory
         }}>
             {props.children}
         </CategoryContext.Provider>


### PR DESCRIPTION
Should be able to now delete a category from the Category Manager page.

1. git fetch --all
2. git checkout sj-deleteCats
3. Navigate to 'category manager' page
4. make sure that you have some categories shown
5. delete a category by pressing the "X" button 
6. verify that the category was deleted and that the page updates accordingly 

Still need to style button that can be done later