### PR TITLE
User posts page now displays only post for current user

### DIFF
--- a/src/components/Posts/UserPostList.js
+++ b/src/components/Posts/UserPostList.js
@@ -1,30 +1,27 @@
-import React, { useContext, useEffect, useState } from "react"
+import React, { useContext, useEffect, useState, useRef } from "react"
 import { Link } from "react-router-dom"
 import { PostContext } from "./PostProvider" 
 import {CategoryContext} from "../categories/CategoriesProvider"
-import {users} from "../auth/AuthProvider"
 import "./Post.css"
 import { makeStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import ArrowForwardIosIcon from '@material-ui/icons/ArrowForwardIos';
 import EditIcon from '@material-ui/icons/Edit';
-import { ProfileContext } from "../auth/AuthProvider"
 
-export const UserPostList = (props) => {
-    const { posts, getAllPosts } = useContext(PostContext)
-    const { profile, getProfile } = useContext(ProfileContext)
+export const PostList = (props) => {
+    const { posts, getAllPosts, getPostsByCategoryId } = useContext(PostContext)
     const { categories, getAllCategories} = useContext(CategoryContext)
-    let yourPosts = posts.filter(post => post.user_id === parseInt(localStorage.getItem("user_id")))
+
+
     useEffect(() => {
         getAllPosts()
-        getProfile()
             .then(getAllCategories)
     }, [])
 
-    const useStyles = makeStyles((theme) => ({
+    const useStyles = makeStyles((thbe) => ({
             root: {
             '& > *': {
-                margin: theme.spacing(1),
+                margin: thbe.spacing(1),
                 color: "#EB5757",  
                 position: "fixed",
                 display: "flex",
@@ -41,32 +38,60 @@ export const UserPostList = (props) => {
     }));
 
     const classes = useStyles()
+    const categoryRef = useRef("")
+
+    const filterPosts = (value) => {
+        if (value ==="0") {
+            getAllPosts()
+        } else {
+            getPostsByCategoryId(value)
+        }
+
+    }
+
+    const userPosts = posts.filter(p => p.IsAuthor === true)
 
     return (
         <>
-            <article className="userArticle">
+            <article className="createArticle">
                 <Button variant="outlined" color="primary" className="createPostButton" onClick={() => props.history.push("/Post/create")}>Create Post</Button>
             </article>
-            
+            <section className="filteredPosts">
+                <label htmlFor="category_id">Filter By Category</label>
+                    <select name="category_id" ref={categoryRef} className="form-control" 
+                    onChange={event => {
+                        event.preventDefault()
+                        filterPosts(categoryRef.current.value)
+                    }}>
+                        <option value="0">Select a Category</option>
+                        {categories.map(c => (
+                            <option key={c.id} value={c.id}>
+                                {c.label}
+                            </option>
+                        ))}
+                    </select>
+            </section>
 
             <article className="postsContainer">
                 {
-                    yourPosts.map(post => {
-                        const category = categories.find(c => c.id === post.category_id) || {}
-                        const userName = profile.find(c => c.id === post.user_id) || {}
+                    userPosts.map(post => {
+                        // const category = categories.find(c => c.id === post.category_id) || {}
+                        
                         return <section key={post.id} className="posts">
                                     <div className="post-info">
-                                        <div className="PostAuthor">{userName.name} </div>
-                                        <div className="PostTitle">{post.title} </div>
-                                        <div className="PostCategory"><Link className="category-list-link" to={{pathname:"/categories"}}> {category.label}</Link></div>
+                                        <div className="PostAuthor">Author: {post.rare_user.user.first_name} {post.rare_user.user.last_name}</div>
+                                        <div className="PostTitle"><Link to={{pathname:`/posts/${post.id}`}}>{post.title}</Link></div>
+                                        <div className="PostCategory"><Link className="category-list-link" to={{pathname:"/categories"}}> {post.category.label}</Link></div>
                                     </div>
                                     <div className="post-icons">
-                                        <button className="postDetailsButton">
-                                            <ArrowForwardIosIcon className={classes.primary} onClick={() => props.history.push(`/posts/${post.id}`)} />
-                                        </button>
-                                        </div>
+                                        <Button className="postDetailsButton" 
+                                                onClick={() => {
+                                                        props.history.push(`/posts/edit/${post.id}`)
+                                                }}>
+                                                <EditIcon style={{ fontSize: 20 }} className={classes.primary} /> 
+                                        </Button>
+                                    </div>
                                     </section>
-                            
                     })
                 }
             </article>
@@ -74,4 +99,4 @@ export const UserPostList = (props) => {
     )
 }
 
-export default UserPostList
+export default PostList


### PR DESCRIPTION
When you click the User Posts link on the nav bar, you will be taken to a page where you can only see posts by the user you are currently logged in as. 

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I ran the front and back end and observed that the filter is working properly by logging in as a user and clicking the link to all posts and then single post. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
