### PR TITLE
Art determine user

### DIFF
--- a/src/components/Profiles/ProfileList.js
+++ b/src/components/Profiles/ProfileList.js
@@ -4,15 +4,15 @@ import "./Profile.css"
 
 
 export const ProfileList = (props) => {
-    const { getAllProfiles, profiles, getSingleProfile, singleProfile } = useContext(ProfileContext)
+    const { getAllProfiles, profiles, getSingleProfile, singleProfile} = useContext(ProfileContext)
 
     useEffect(() => {
         getAllProfiles()
-        getSingleProfile()
     }, [])
 
-    console.log(singleProfile)
-
+    let admins = profiles.filter(p => p.user.is_staff == true)
+    console.log(admins)
+    
         return (
             <article className="profileContainer">
             {

--- a/src/components/Profiles/ProfileList.js
+++ b/src/components/Profiles/ProfileList.js
@@ -8,11 +8,11 @@ export const ProfileList = (props) => {
 
     useEffect(() => {
         getAllProfiles()
+        getSingleProfile(userNumber)
     }, [])
 
-    let admins = profiles.filter(p => p.user.is_staff == true)
-    console.log(admins)
-    
+    let userNumber = localStorage.getItem("rareUser_number")
+    if (singleProfile.is_staff){
         return (
             <article className="profileContainer">
             {
@@ -22,13 +22,32 @@ export const ProfileList = (props) => {
                                     <div className="profileUsername">{p.user.username}</div>
                                     <div className="profileFullName">{p.user.first_name} {p.user.last_name}</div>
                                     <div className="profile_Is_Staff">{p.IsAdmin}</div>
+                                    <button>Deactivate User</button>
                                 </div>
                             </section>
 
                 })
             }
         </article>
-        )
+        )} else{
+            return (
+                <article className="profileContainer">
+                {
+                    profiles.map(p => {
+                        return <section key={p.id} className="profiles">
+                                    <div className="profile-info">
+                                        <div className="profileUsername">{p.user.username}</div>
+                                        <div className="profileFullName">{p.user.first_name} {p.user.last_name}</div>
+                                        <div className="profile_Is_Staff">{p.IsAdmin}</div>
+                                    </div>
+                                </section>
+    
+                    })
+                }
+            </article>
+            )
+
+        }
     
 
 }

--- a/src/components/Profiles/ProfileProvider.js
+++ b/src/components/Profiles/ProfileProvider.js
@@ -26,7 +26,7 @@ export const UserProfileProvider = (props) => {
 
     return (
         <ProfileContext.Provider value={{
-            getAllProfiles, profiles, getSingleProfile, singleProfile
+            getAllProfiles, profiles, singleProfile, getSingleProfile
         }}>
             {props.children}
         </ProfileContext.Provider>

--- a/src/components/auth/Login.js
+++ b/src/components/auth/Login.js
@@ -27,6 +27,7 @@ export const Login = () => {
             .then(res => {
                 if (res.valid) {
                     localStorage.setItem("rareUser_id", res.token )
+                    localStorage.setItem("rareUser_number", res.user_no)
                     history.push("/posts")
                 }
                 else {


### PR DESCRIPTION
Local storage now contains the simple Id number of a user upon login. This number is used to pull down a copy of the single user's info, which contains the is_staff variable. The front end then checks whether this variable is true. If so, it places buttons below each user on the user view tab. 

- [ ] New feature (non-breaking change which adds functionality)

I checked the local storage for the new variable. I then logged in as an admin and saw the buttons. Finally, I logged in as a non-admin and saw the buttons were not there. 

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x]  I have made corresponding changes to the documentation
- [x]  My changes generate no new warnings
- [x]  I have added tests that prove my fix is effective or that my feature works
- [x]  New and existing unit tests pass locally with my changes
- [x]  Any dependent changes have been merged and published in downstream modules
