### PR TITLE
admin user can now view deactivated profiles

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -20,6 +20,7 @@ import { PostForm } from "./Posts/PostForm"
 import { PostTagProvider } from "./tags/PostTagProvider"
 import { CategoryEdit } from "./categories/CategoryEdit"
 import { ProfileList } from "./Profiles/ProfileList"
+import { DeactivatedList } from "./Profiles/DeactivatedList"
 import { UserProfileProvider } from "./Profiles/ProfileProvider"
 
 export const ApplicationViews = () => {
@@ -119,8 +120,12 @@ export const ApplicationViews = () => {
             </PostsProvider>
 
             <UserProfileProvider>
-                <Route path="/userprofiles" render ={(props) => {
+                <Route exact path="/userprofiles" render ={(props) => {
                                 return <ProfileList {...props}/>
+                            }}>
+                </Route>
+                <Route path="/userprofiles/deactivated" render ={(props) => {
+                                return <DeactivatedList {...props}/>
                             }}>
                 </Route>
             </UserProfileProvider>

--- a/src/components/Profiles/DeactivatedList.js
+++ b/src/components/Profiles/DeactivatedList.js
@@ -12,6 +12,28 @@ export const DeactivatedList = (props) => {
 
     let userNumber = localStorage.getItem("rareUser_number")
 
+    const deactivate_profile_prompt = (id) => {
+        var retVal = window.confirm("Are you sure you want to deactivate this user's account?");
+        if( retVal == true ) {
+            updateActive(id)
+            props.history.push("/userprofiles")
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    const reactivate_profile_prompt = (id) => {
+        var retVal = window.confirm("Are you sure you want to reactivate this user's account?");
+        if( retVal == true ) {
+            updateActive(id)
+            props.history.push("/userprofiles")
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     const filteredProfiles = profiles.filter(p => {
         return p.active === false
     }) || {}
@@ -28,13 +50,18 @@ export const DeactivatedList = (props) => {
                                     <div className="profileUsername">{p.user.username}</div>
                                     <div className="profileFullName">{p.user.first_name} {p.user.last_name}</div>
                                     <div className="profile_Is_Staff">{p.IsAdmin}</div>
+                                    {
+                                        (p.active === true) ?                         
+                                        <button className={p.id} onClick={() => deactivate_profile_prompt(p.id)}>Deactivate User</button>
+                                        : <button className={p.id} onClick={() => reactivate_profile_prompt(p.id)}>Activate User</button>
+                                    }
                                 </div>
-                                <button onClick={() => {
-                            props.history.push("/userprofiles")
-                            }}>Back</button>
                             </section>
                 })
             }
+                <button onClick={() => {
+            props.history.push("/userprofiles")
+            }}>Back</button>
         </article>
         )} else {
             return <div>No Users Are Currently Deactivated</div>

--- a/src/components/Profiles/DeactivatedList.js
+++ b/src/components/Profiles/DeactivatedList.js
@@ -1,0 +1,42 @@
+import React, { useContext, useEffect, useState, useRef } from "react"
+import { ProfileContext } from "./ProfileProvider" 
+import "./Profile.css"
+
+export const DeactivatedList = (props) => {
+    const { getAllProfiles, profiles, getSingleProfile, singleProfile, updateActive, makeAdmin} = useContext(ProfileContext)
+
+    useEffect(() => {
+        getAllProfiles()
+        getSingleProfile(userNumber)
+    }, [])
+
+    let userNumber = localStorage.getItem("rareUser_number")
+
+    const filteredProfiles = profiles.filter(p => {
+        return p.active === false
+    }) || {}
+
+    console.log(filteredProfiles)
+
+    if (singleProfile.is_staff){
+        return (
+        <article className="profileContainer">
+            {
+                filteredProfiles.map(p => {
+                    return <section key={p.id} className="profiles">
+                                <div className="profile-info">
+                                    <div className="profileUsername">{p.user.username}</div>
+                                    <div className="profileFullName">{p.user.first_name} {p.user.last_name}</div>
+                                    <div className="profile_Is_Staff">{p.IsAdmin}</div>
+                                </div>
+                                <button onClick={() => {
+                            props.history.push("/userprofiles")
+                            }}>Back</button>
+                            </section>
+                })
+            }
+        </article>
+        )} else {
+            return <div>No Users Are Currently Deactivated</div>
+        }
+}

--- a/src/components/Profiles/ProfileList.js
+++ b/src/components/Profiles/ProfileList.js
@@ -72,9 +72,9 @@ export const ProfileList = (props) => {
                                     <div className="profileFullName">{p.user.first_name} {p.user.last_name}</div>
                                     <div className="profile_Is_Staff">{p.IsAdmin}</div>
                                     {
-                                        (p.active === true) ?                         
+                                        (p.active === true) ?                       
                                         <button className={p.id} onClick={() => deactivate_profile_prompt(p.id)}>Deactivate User</button>
-                                        : <button className={p.id} onClick={() => reactivate_profile_prompt(p.id)}>Activate User</button>
+                                        : <div></div>
                                     }
                                     {
                                         (p.user.is_staff === true) ?                         

--- a/src/components/Profiles/ProfileList.js
+++ b/src/components/Profiles/ProfileList.js
@@ -85,6 +85,9 @@ export const ProfileList = (props) => {
                             </section>
                 })
             }
+                <button onClick={() => {
+            props.history.push("/userprofiles/deactivated")
+            }}>View Deactivated</button>
         </article>
         )} else{
             return (


### PR DESCRIPTION
Created a Deactivated List where only admins can see a list of deactivated profiles. If your user is admin, you should see "View Deactivated". On Click a list of profiles that are deactivated should be shown.

[] Bug fix (non-breaking change which fixes an issue)
[] New feature (non-breaking change which adds functionality)
[] Breaking change (fix or feature that would cause existing functionality to not work as expected)
[] This change requires a documentation update

How Has This Been Tested?

Checklist:
 My code follows the style guidelines of this project
[] I have performed a self-review of my own code
[] I have commented my code, particularly in hard-to-understand areas
[] I have made corresponding changes to the documentation
[] My changes generate no new warnings
[] I have added tests that prove my fix is effective or that my feature works
[] New and existing unit tests pass locally with my changes
[] Any dependent changes have been merged and published in downstream modules