### PR TITLE
admin can now unnapprove and approve posts, when new post is created, post is unapproved

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -32,36 +32,38 @@ export const ApplicationViews = () => {
                         <CategoriesProvider>
                             <TagProvider>
                                 <SubscriptionProvider>
-                                <Route exact path="/categories" render={(props) => {
-                                return <> 
-                                    <CategoriesList history={props.history} />
-                                </>
-                                }} />    
-                                <Route exact path="/categories/edit/:categoryId(\d+)" render={(props) => {
-                                return <> 
-                                    <CategoryEdit {...props} />
-                                </>
-                                }} />    
-                                <Route exact path="/posts" render={(props) => {
+                                    <UserProfileProvider>
+                                    <Route exact path="/categories" render={(props) => {
                                     return <> 
-                                        <PostList history={props.history} />
+                                        <CategoriesList history={props.history} />
                                     </>
-                                }} /> 
-                                <Route exact path="/userposts" render={(props) => {
-                                    return <>
-                                        <UserPostList history={props.history} />
+                                    }} />    
+                                    <Route exact path="/categories/edit/:categoryId(\d+)" render={(props) => {
+                                    return <> 
+                                        <CategoryEdit {...props} />
                                     </>
-                                }} /> 
-                                <Route exact path="/comments/:sampleId(\d+)" render={(props) => {
-                                    return <>
-                                        <EditCommentForm {...props}/>
-                                    </>
-                                }} />
-                                <Route exact path="/subscriptions" render={(props) => {
-                                    return <>
-                                        <SubscriptionList history={props.history} />
-                                    </>
-                                }} />
+                                    }} />    
+                                    <Route exact path="/posts" render={(props) => {
+                                        return <> 
+                                            <PostList history={props.history} />
+                                        </>
+                                    }} /> 
+                                    <Route exact path="/userposts" render={(props) => {
+                                        return <>
+                                            <UserPostList history={props.history} />
+                                        </>
+                                    }} /> 
+                                    <Route exact path="/comments/:sampleId(\d+)" render={(props) => {
+                                        return <>
+                                            <EditCommentForm {...props}/>
+                                        </>
+                                    }} />
+                                    <Route exact path="/subscriptions" render={(props) => {
+                                        return <>
+                                            <SubscriptionList history={props.history} />
+                                        </>
+                                    }} />
+                                    </UserProfileProvider>
                                 </SubscriptionProvider>     
                             </TagProvider>
                         </CategoriesProvider>
@@ -116,6 +118,7 @@ export const ApplicationViews = () => {
             <PostsProvider>
                 <CategoriesProvider>
                     <TagProvider>
+                        <UserProfileProvider>
                         <Route path="/posts/create" render ={(props) => {
                             return <PostForm {...props}/>
                         }}>
@@ -124,6 +127,7 @@ export const ApplicationViews = () => {
                             return <PostForm {...props} /> 
                             }}>
                         </Route>
+                        </UserProfileProvider>
                     </TagProvider>
                 </CategoriesProvider>
             </PostsProvider>

--- a/src/components/Posts/PostForm.js
+++ b/src/components/Posts/PostForm.js
@@ -60,7 +60,7 @@ export const PostForm = (props) => {
                 date: now.toISODate(),
                 category_id: categoryId,
                 image_url: postState.image_url,
-                approved: true
+                approved: false
             })
 
                 .then(() => props.history.push("/posts"))
@@ -71,7 +71,7 @@ export const PostForm = (props) => {
                 date: now.toISODate(),
                 category_id: categoryId,
                 image_url: "",
-                approved: true
+                approved: false
             })
                 .then(() => props.history.push("/posts"))
         }

--- a/src/components/Posts/PostList.js
+++ b/src/components/Posts/PostList.js
@@ -1,6 +1,7 @@
 import React, { useContext, useEffect } from "react"
 import { Link } from "react-router-dom"
 import { PostContext } from "./PostProvider" 
+import { ProfileContext } from "../Profiles/ProfileProvider" 
 import "./Post.css"
 import { makeStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
@@ -10,10 +11,14 @@ import {HumanDate} from '../utils/HumanDate'
 import { DateTime } from "luxon"
 
 export const PostList = (props) => {
-    const { posts, getAllPosts, deletePost } = useContext(PostContext)
+    const { posts, getAllPosts, deletePost, updatePostApproval } = useContext(PostContext)
+    const { getSingleProfile, singleProfile } = useContext(ProfileContext)
 
+    
+    const currentUser = localStorage.getItem("rareUser_number")
 
     useEffect(() => {
+        getSingleProfile(currentUser)
         getAllPosts()
     }, [])
 
@@ -28,8 +33,8 @@ export const PostList = (props) => {
                 background: "black",
                 margin: 0
             },
-            },
-            primary: {
+        },
+        primary: {
             '& > *': {
                 color: "black"
             },
@@ -47,6 +52,27 @@ export const PostList = (props) => {
         }
     }
 
+    const approve_post_prompt = (id) => {
+        var retVal = window.confirm("Are you sure you want to approve this user's post?");
+        if( retVal == true ) {
+            updatePostApproval(id)
+            props.history.push("/posts")
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    const unapprove_post_prompt = (id) => {
+        var retVal = window.confirm("Are you sure you want to unapprove this user's post?");
+        if( retVal == true ) {
+            updatePostApproval(id)
+            props.history.push("/posts")
+            return true;
+        } else {
+            return false;
+        }
+    }
 
     const classes = useStyles()
 
@@ -60,15 +86,16 @@ export const PostList = (props) => {
                 {
                     posts.map(post => {
 
-
+                        console.log(post, "post")
 
                         if(post.IsAuthor){
                             return <section key={post.id} className="posts">
-                                        <div className="post-info">
+                                <div className="post-info">
                                             <div className="PostAuthor">Author: {post.rare_user.user.first_name} {post.rare_user.user.last_name}</div>
                                             <div className="PostTitle"><Link to={{pathname:`/posts/${post.id}`}}>{post.title}</Link></div>
                                             <div className="PostCategory"><Link className="category-list-link" to={{pathname:"/categories"}}> {post.category.label}</Link></div>
                                         </div>
+
                                         <div className="post-icons">
                                             <Button className="postDetailsButton" 
                                                     onClick={() => {
@@ -78,7 +105,14 @@ export const PostList = (props) => {
                                             </Button>
                                             <button className="btn postDetails__delete_btn" onClick={() => delete_prompt(post.id)}><DeleteIcon style={{ fontSize: 20 }} className={classes.primary} /></button>
                                         </div>
-                                        </section>
+                                        {
+                                            (singleProfile.is_staff)?
+                                                (post.approved === false) ?                         
+                                                    <button className={post.id} onClick={() => approve_post_prompt(post.id)}>Approve</button>
+                                                : <button className={post.id} onClick={() => unapprove_post_prompt(post.id)}>Unapprove</button>
+                                            : <div></div>
+                                        }   
+                                    </section>
                         } else {
                             return <section key={post.id} className="posts">
                                     <div className="post-info">
@@ -88,12 +122,20 @@ export const PostList = (props) => {
                                     </div>
                                     <div className="post-icons"></div>
                                     
+                                    {
+                                        (singleProfile.is_staff)?
+                                            (post.approved === false) ?                         
+                                                <button className={post.id} onClick={() => approve_post_prompt(post.id)}>Approve</button>
+                                            : <button className={post.id} onClick={() => unapprove_post_prompt(post.id)}>Unapprove</button>
+                                        : <div></div>
+                                    }
                                 </section>
                         }
                     }
                     )
                     .reverse()
                 }
+
             </article>
         </>
     )

--- a/src/components/Posts/PostProvider.js
+++ b/src/components/Posts/PostProvider.js
@@ -65,10 +65,22 @@ export const PostsProvider = (props) => {
             .then(setPost);
     }
 
+    const updatePostApproval = post => {
+        return fetch(`http://localhost:8000/approvepost/${post}`, {
+            method: "PUT",
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Token ${localStorage.getItem("rareUser_id")}`
+            },
+            body: JSON.stringify(post)
+        })
+            .then(getAllPosts)
+    }
+
     return (
         <PostContext.Provider value={{
             posts, getAllPosts, singlePost, getSinglePost,
-            createPost, editPost, deletePost, getPostTags
+            createPost, editPost, deletePost, getPostTags, updatePostApproval
         }}>
             {props.children}
         </PostContext.Provider>


### PR DESCRIPTION
# Description

If user is an admin, they are able to approve or unapproved a post. When a new post is created the post should be unapproved until an admin clicks approve.

Fixes # (issue)

Created 1 new file in posts. Added a fetch call to postprovider so the post can be updated.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

Verify that the approve/unapproved buttons only show up if user is admin. Verify that when user is admin and clicks the unapproved button the post will change to approved and vice versa. Verify that when you create a new post that post will automatically be unapproved when first created. 

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
